### PR TITLE
Fix escape for multi-line comments

### DIFF
--- a/scala.xml
+++ b/scala.xml
@@ -55,7 +55,7 @@
   	<IMPORT DELEGATE="XML_SHARED"/>
 	
     <!-- string and character literals -->
-    <SPAN TYPE="LITERAL1" NO_LINE_BREAK="FALSE" ESCAPE="FALSE">
+    <SPAN TYPE="LITERAL1" NO_LINE_BREAK="FALSE" ESCAPE="">
       <BEGIN>"""</BEGIN>
       <END>"""</END>
     </SPAN>


### PR DESCRIPTION
Currently the string "false" at the end of the literal prevents the highlighter from terminating the literal.
